### PR TITLE
fix agreements example

### DIFF
--- a/src/main/assembly/dist/examples/bag/agreements/example1.xml
+++ b/src/main/assembly/dist/examples/bag/agreements/example1.xml
@@ -19,10 +19,9 @@
 <agreements xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/ https://easy.dans.knaw.nl/schemas/bag/metadata/agreements/agreements.xsd"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:dcterms="http://purl.org/dc/terms/"
-            xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
->
+            xmlns="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
     <depositAgreement>
-        <signerId easy-account="user001">MisterX</signerId>
+        <depositorId>user001</depositorId>
         <dcterms:dateAccepted>2018-03-22T21:43:01.000+01:00</dcterms:dateAccepted>
         <depositAgreementAccepted>true</depositAgreementAccepted>
     </depositAgreement>


### PR DESCRIPTION
I found an old example where still `signerId` was used, rather than `depositorId`.
@lindareijnhoudt can you confirm this?

@DANS-KNAW/easy for review