### PR TITLE
Make language codes confirm to correct ISO 639 table

### DIFF
--- a/src/main/assembly/dist/examples/ddm/example2.xml
+++ b/src/main/assembly/dist/examples/ddm/example2.xml
@@ -225,10 +225,10 @@
 
         <dcterms:language>Nederlands</dcterms:language>
         <dc:language>Engels</dc:language>
-        <dc:language xsi:type='dcterms:ISO639-3'>Ned</dc:language>
-        <dc:language xsi:type='dcterms:ISO639-2'>en</dc:language>
-        <dcterms:language xsi:type='dcterms:ISO639-3'>Dui</dcterms:language>
-        <dcterms:language xsi:type='dcterms:ISO639-2'>fr</dcterms:language>
+        <dc:language xsi:type='dcterms:ISO639-3'>nld</dc:language>
+        <dc:language xsi:type='dcterms:ISO639-2'>eng</dc:language>
+        <dcterms:language xsi:type='dcterms:ISO639-3'>deu</dcterms:language>
+        <dcterms:language xsi:type='dcterms:ISO639-2'>fre</dcterms:language>
 
         <!-- =================================================== misceleneous -->
 


### PR DESCRIPTION
NO EASY

#### When applied it will
* use the correct values in the language tags, according to either ISO 639.2 or 639.3

#### Where should the reviewer @DANS-KNAW/easy start?
