### PR TITLE
EASY-2205: Add example of isFormatOf with scheme attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <easy.schema.version>2.1.9</easy.schema.version>
+        <easy.schema.version>2.1.10</easy.schema.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <easy.schema.version>2.1.4</easy.schema.version>
+        <easy.schema.version>2.1.9</easy.schema.version>
     </properties>
 
     <scm>

--- a/src/main/assembly/dist/examples/ddm/example1.xml
+++ b/src/main/assembly/dist/examples/ddm/example1.xml
@@ -128,6 +128,11 @@
 
         <ddm:relation href="http://www.example.com">example.com</ddm:relation>
         <ddm:isPartOf href="http://doi.org/journaldoi">journal title</ddm:isPartOf>
+        <ddm:relation scheme="STREAMING_SURROGATE_RELATION">datavault-path</ddm:relation>
+        <ddm:isFormatOf href="https://doi.org/10.17026/test-123-456" scheme="DOI">https://doi.org/10.17026/test-123-456</ddm:isFormatOf>
+        <ddm:isFormatOf scheme="id-type:ARCHIS-ZAAK-IDENTIFICATIE">55657</ddm:isFormatOf>
+        <dcterms:requires>a description of a related resource</dcterms:requires>
+        <ddm:references scheme="URL" href="http://www.link.to/webresource">A related webresource</ddm:references>
 
         <!-- Use 'name=value' and ';' for lists of items that belong together -->
         <dc:coverage xsi:type="dct:Period">name=The Great Depression; start=1929; end=1939;</dc:coverage>

--- a/src/main/assembly/dist/examples/ddm/example1.xml
+++ b/src/main/assembly/dist/examples/ddm/example1.xml
@@ -19,6 +19,7 @@
 <ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
     xmlns:dct="http://purl.org/dc/terms/"
     xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
     xsi:schemaLocation="

--- a/src/main/assembly/dist/examples/ddm/example1.xml
+++ b/src/main/assembly/dist/examples/ddm/example1.xml
@@ -19,7 +19,6 @@
 <ddm:DDM xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dcterms="http://purl.org/dc/terms/"
     xmlns:dct="http://purl.org/dc/terms/"
     xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
     xsi:schemaLocation="
@@ -132,7 +131,7 @@
         <ddm:relation scheme="STREAMING_SURROGATE_RELATION">datavault-path</ddm:relation>
         <ddm:isFormatOf href="https://doi.org/10.17026/test-123-456" scheme="DOI">https://doi.org/10.17026/test-123-456</ddm:isFormatOf>
         <ddm:isFormatOf scheme="id-type:ARCHIS-ZAAK-IDENTIFICATIE">55657</ddm:isFormatOf>
-        <dcterms:requires>a description of a related resource</dcterms:requires>
+        <dct:requires>a description of a related resource</dct:requires>
         <ddm:references scheme="URL" href="http://www.link.to/webresource">A related webresource</ddm:references>
 
         <!-- Use 'name=value' and ';' for lists of items that belong together -->

--- a/src/main/assembly/dist/examples/ddm/example2.xml
+++ b/src/main/assembly/dist/examples/ddm/example2.xml
@@ -143,9 +143,9 @@
         <ddm:relation scheme="STREAMING_SURROGATE_RELATION">/domain/dans/user/somebody/collection/test1/presentation/testA</ddm:relation>
         <dc:relation>urn:nbn:nl:ui:13-fant-asy</dc:relation>
         <dcterms:relation>10.5072/fantasy-doi-rel</dcterms:relation>
-        <dcterms:conformsTo>http://doi.org/10.1111/sode.12120</dcterms:conformsTo>
-        <dcterms:isVersionOf>http://hdl.handle.net/2066/121062</dcterms:isVersionOf>
-        <dcterms:hasVersion>http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</dcterms:hasVersion>
+        <ddm:conformsTo scheme="DOI">http://doi.org/10.1111/sode.12120</ddm:conformsTo>
+        <ddm:isVersionOf href="http://hdl.handle.net/2066/121062">http://hdl.handle.net/2066/121062</ddm:isVersionOf>
+        <ddm:hasVersion scheme="URN">http://www.persistent-identifier.nl/?identifier=urn:nbn:nl:ui:13-2ajw-cq</ddm:hasVersion>
         <dcterms:isReplacedBy>A descriptin of object 6</dcterms:isReplacedBy>
         <dcterms:replaces>A descriptin of object 7</dcterms:replaces>
         <dcterms:isRequiredBy>A descriptin of object 8</dcterms:isRequiredBy>


### PR DESCRIPTION
Fixes EASY-2205

#### When applied it will
* Add example of isFormatOf with scheme attribute
* [x] merge [PR#71](https://github.com/DANS-KNAW/easy-schema/pull/71) in easy-schema
* [x] release a new version of easy-schema to the production server

#### Where should the reviewer @DANS-KNAW/easy start?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-schema                      | [PR#71](https://github.com/DANS-KNAW/easy-schema/pull/71)     | this PR will only validate once the schema has been deployed
