### PR TITLE
EASY-2614: ISNI regexp allowed 17 digits if the last is an X 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <easy.schema.version>3.3.2-SNAPSHOT</easy.schema.version>
+        <easy.schema.version>3.3.2</easy.schema.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <easy.schema.version>3.3.1</easy.schema.version>
+        <easy.schema.version>3.3.2-SNAPSHOT</easy.schema.version>
     </properties>
 
     <scm>

--- a/src/main/resources/examples/dcx-dai/example2.xml
+++ b/src/main/resources/examples/dcx-dai/example2.xml
@@ -17,7 +17,7 @@
 
 -->
 <dcx-dai:creatorDetails xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-                        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/dai/ https://easy.dans.knaw.nl/schemas/dcx/2019/01/dcx-dai.xsd">
+                        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/dai/ https://easy.dans.knaw.nl/schemas/dcx/2020/03/dcx-dai.xsd">
     <dcx-dai:author>
         <dcx-dai:titles xml:lang="en">B.L.I.S.</dcx-dai:titles>
         <dcx-dai:initials>J.P.H.</dcx-dai:initials>

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/AgreementsSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/AgreementsSchemaSpec.scala
@@ -15,17 +15,14 @@
  */
 package nl.knaw.dans.easy.schemaExamples
 
+import better.files.File
 import org.scalatest.prop.TableFor1
 
 class AgreementsSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/bag/metadata/agreements/agreements.xsd"
   override val localSchemaFile: String = lastLocalXsd("bag/metadata/agreements", "agreements.xsd")
-  override val examples: TableFor1[String] = Table(
-    "example",
-    "bag/agreements/example1.xml",
+  override val examples: TableFor1[File] = Table("file",
+    exampleDir / "bag/agreements/example1.xml",
   )
-  forEvery(examples) { example =>
-    (exampleDir / example).contentAsString should include(publicSchema)
-  }
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/CollectionsDmoSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/CollectionsDmoSchemaSpec.scala
@@ -15,14 +15,14 @@
  */
 package nl.knaw.dans.easy.schemaExamples
 
+import better.files.File
 import org.scalatest.prop.TableFor1
 
 class CollectionsDmoSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/collections/dmo-collection.xsd"
   override val localSchemaFile: String = (schemaDir / "collections/dmo-collection.xsd").toString()
-  override val examples: TableFor1[String] = Table(
-    "example",
-    "collections/dmo/example1.xml",
+  override val examples: TableFor1[File] = Table("file",
+    exampleDir / "collections/dmo/example1.xml",
   )
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
@@ -27,48 +27,6 @@ class DcxDaiSchemaSpec extends SchemaValidationFixture {
     testDir.createDirectories()
     Table("file",
       exampleDir / "dcx-dai/example2.xml",
-      (testDir / "isni0.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:ISNI>0000 0001 2103 2683</dcx-dai:ISNI>")),
-      (testDir / "isni1.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>0000000121032268</dcx-dai:ISNI>")),
-      (testDir / "isni2.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>")),
-      (testDir / "isni3.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI: 0000 0001 2103 2268</dcx-dai:ISNI>")),
-      (testDir / "isni4.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI:0000 0001 2103 2268</dcx-dai:ISNI>")),
-      (testDir / "isni5.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI 0000 0001 2103 2268</dcx-dai:ISNI>")),
-      (testDir / "isni6.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI0000000121032268</dcx-dai:ISNI>")),
-      (testDir / "orcid1.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>https://orcid.org/0000-0002-1825-009x</dcx-dai:ORCID>")),
-      (testDir / "orcid2.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>0000-0002-1825-009X</dcx-dai:ORCID>")),
-      (testDir / "dai1.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789</dcx-dai:DAI>")),
-      (testDir / "dai2.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789x</dcx-dai:DAI>")),
-      (testDir / "dai3.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789X</dcx-dai:DAI>")),
-      (testDir / "dai4.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>info:eu-repo/dai/nl/123456789</dcx-dai:DAI>")),
     )
-  }
-
-  "ISNI validation" should "report X as 17th digit" in {
-    validateWithLocal(modify(
-      """.*<dcx-dai:DAI>.*""",
-      "<dcx-dai:ISNI>00000001210322683X</dcx-dai:ISNI>"
-    )) should notMatchRegexpInXsd
-  }
-
-  it should "report X as 17th digit in URL" in {
-    validateWithLocal(modify(
-      """.*<dcx-dai:DAI>.*""",
-      "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683X</dcx-dai:ISNI>"
-    )) should notMatchRegexpInXsd
-  }
-
-  "DAI validation" should "report missing check digit with only 8 digits" in {
-    validateWithLocal(modify(
-      """.*<dcx-dai:DAI>.*""",
-      "<dcx-dai:DAI>12345678</dcx-dai:DAI>"
-    )) should notMatchRegexpInXsd
-  }
-
-  private def modify(lineMatches: String, replacement: String) = {
-    File("src/main/resources/examples/dcx-dai/example2.xml")
-      .contentAsString.split("\n")
-      .map(line => if (line.matches(lineMatches)) replacement
-                   else line
-      ).mkString("\n")
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
@@ -18,8 +18,6 @@ package nl.knaw.dans.easy.schemaExamples
 import better.files.File
 import org.scalatest.prop.TableFor1
 
-import scala.util.Success
-
 class DcxDaiSchemaSpec extends SchemaValidationFixture {
 
   override val localSchemaFile: String = lastLocalXsd("dcx", "dcx-dai.xsd")
@@ -29,32 +27,42 @@ class DcxDaiSchemaSpec extends SchemaValidationFixture {
     testDir.createDirectories()
     Table("file",
       exampleDir / "dcx-dai/example2.xml",
-      (testDir / "isni1.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:ISNI>0000 0001 2103 2683</dcx-dai:ISNI>")),
-      (testDir / "isni2.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:ISNI>00000001 2103 2683</dcx-dai:ISNI>")),
-      (testDir / "isni3.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>")),
-      // TODO More variants, also ORCID and DAI. NOTE: the latter regexp is defined both in ddm.xsd as in dcx-dai.xsd
+      (testDir / "isni0.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:ISNI>0000 0001 2103 2683</dcx-dai:ISNI>")),
+      (testDir / "isni1.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>0000000121032268</dcx-dai:ISNI>")),
+      (testDir / "isni2.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>")),
+      (testDir / "isni3.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI: 0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni4.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI:0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni5.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI 0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni6.xml").write(modify(".*<dcx-dai:role>.*", "<dcx-dai:ISNI>ISNI0000000121032268</dcx-dai:ISNI>")),
+      (testDir / "orcid1.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>https://orcid.org/0000-0002-1825-009x</dcx-dai:ORCID>")),
+      (testDir / "orcid2.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>0000-0002-1825-009X</dcx-dai:ORCID>")),
+      (testDir / "dai1.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789</dcx-dai:DAI>")),
+      (testDir / "dai2.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789x</dcx-dai:DAI>")),
+      (testDir / "dai3.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789X</dcx-dai:DAI>")),
+      (testDir / "dai4.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>info:eu-repo/dai/nl/123456789</dcx-dai:DAI>")),
+      // TODO NOTE: the DAI regexp is defined both in ddm.xsd as in dcx-dai.xsd
     )
   }
 
-  "ISNI validation" should "fail with X as 17th digit" in {
+  "ISNI validation" should "report X as 17th digit" in {
     validateWithLocal(modify(
       """.*<dcx-dai:DAI>.*""",
       "<dcx-dai:ISNI>00000001210322683X</dcx-dai:ISNI>"
     )) should notMatchRegexpInXsd
   }
 
-  it should "fail with X as 17th digit in URL" in pendingUntilFixed {
+  it should "report X as 17th digit in URL" in {
     validateWithLocal(modify(
       """.*<dcx-dai:DAI>.*""",
       "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683X</dcx-dai:ISNI>"
     )) should notMatchRegexpInXsd
   }
 
-  it should "succeed with separators" in pendingUntilFixed { // move to examples table when fixed
+  "DAI validation" should "report missing check digit with only 8 digits" in {
     validateWithLocal(modify(
-      """.*<dcx-dai:role>.*""",
-      "<dcx-dai:ISNI>ISNI: 0000 00012 1032 2683</dcx-dai:ISNI>"
-    )) shouldBe a[Success[_]]
+      """.*<dcx-dai:DAI>.*""",
+      "<dcx-dai:DAI>12345678</dcx-dai:DAI>"
+    )) should notMatchRegexpInXsd
   }
 
   private def modify(lineMatches: String, replacement: String) = {

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
@@ -40,7 +40,6 @@ class DcxDaiSchemaSpec extends SchemaValidationFixture {
       (testDir / "dai2.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789x</dcx-dai:DAI>")),
       (testDir / "dai3.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789X</dcx-dai:DAI>")),
       (testDir / "dai4.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>info:eu-repo/dai/nl/123456789</dcx-dai:DAI>")),
-      // TODO NOTE: the DAI regexp is defined both in ddm.xsd as in dcx-dai.xsd
     )
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
@@ -16,11 +16,9 @@
 package nl.knaw.dans.easy.schemaExamples
 
 import better.files.File
-import org.scalatest.matchers.Matcher
 import org.scalatest.prop.TableFor1
 
-import scala.util.{ Failure, Success }
-import scala.xml.SAXParseException
+import scala.util.Success
 
 class DcxDaiSchemaSpec extends SchemaValidationFixture {
 
@@ -38,25 +36,25 @@ class DcxDaiSchemaSpec extends SchemaValidationFixture {
     )
   }
 
-  "ISNI validation" should "fail with X as 17th digit" in  {
-    validateVariant(""".*<dcx-dai:DAI>.*""", "<dcx-dai:ISNI>00000001210322683X</dcx-dai:ISNI>") should notMatchRegexpInXsd
+  "ISNI validation" should "fail with X as 17th digit" in {
+    validateWithLocal(modify(
+      """.*<dcx-dai:DAI>.*""",
+      "<dcx-dai:ISNI>00000001210322683X</dcx-dai:ISNI>"
+    )) should notMatchRegexpInXsd
   }
 
   it should "fail with X as 17th digit in URL" in pendingUntilFixed {
-    validateVariant(""".*<dcx-dai:DAI>.*""", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683X</dcx-dai:ISNI>") should notMatchRegexpInXsd
+    validateWithLocal(modify(
+      """.*<dcx-dai:DAI>.*""",
+      "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683X</dcx-dai:ISNI>"
+    )) should notMatchRegexpInXsd
   }
 
   it should "succeed with separators" in pendingUntilFixed { // move to examples table when fixed
-    validateVariant(""".*<dcx-dai:role>.*""", "<dcx-dai:ISNI>ISNI: 0000 00012 1032 2683</dcx-dai:ISNI>") shouldBe a[Success[_]]
-  }
-
-  private def notMatchRegexpInXsd: Matcher[Any] = matchPattern {
-    case Failure(e: SAXParseException) if e.getMessage.contains("is not facet-valid with respect to pattern") =>
-  }
-
-  private def validateVariant(lineMatches: String, replacement: String) = {
-    assume(schemaIsOnline(triedLocalSchema))
-    validate(triedLocalSchema, modify(lineMatches, replacement))
+    validateWithLocal(modify(
+      """.*<dcx-dai:role>.*""",
+      "<dcx-dai:ISNI>ISNI: 0000 00012 1032 2683</dcx-dai:ISNI>"
+    )) shouldBe a[Success[_]]
   }
 
   private def modify(lineMatches: String, replacement: String) = {

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DcxDaiSchemaSpec.scala
@@ -22,11 +22,7 @@ class DcxDaiSchemaSpec extends SchemaValidationFixture {
 
   override val localSchemaFile: String = lastLocalXsd("dcx", "dcx-dai.xsd")
   override val publicSchema: String = localSchemaFile.toString.replace(schemaDir.toString(), httpsEasySchemaBase)
-  override val examples: TableFor1[File] = {
-    if (testDir.exists) testDir.delete()
-    testDir.createDirectories()
-    Table("file",
-      exampleDir / "dcx-dai/example2.xml",
-    )
-  }
+  override val examples: TableFor1[File] = Table("file",
+    exampleDir / "dcx-dai/example2.xml",
+  )
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
@@ -16,14 +16,22 @@
 package nl.knaw.dans.easy.schemaExamples
 
 import better.files.File
+import org.scalatest.matchers.Matcher
 import org.scalatest.prop.TableFor1
 
 import scala.util.Failure
+import scala.xml.{ SAXParseException, XML }
 
 class DdmSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/md/ddm/ddm.xsd"
   override val localSchemaFile: String = lastLocalXsd("md", "ddm.xsd")
+
+  private lazy val toModify = {
+    val file = (exampleDir / "ddm/example1.xml").toString
+    toLocalSchemas(XML.loadFile(file)).split("\n")
+  }
+
   override val examples: TableFor1[File] = {
     if (testDir.exists) testDir.delete()
     testDir.createDirectories()
@@ -33,23 +41,30 @@ class DdmSchemaSpec extends SchemaValidationFixture {
       exampleDir / "ddm/example1.xml",
       exampleDir / "ddm/example2.xml",
       exampleDir / "abr-type/example1.xml",
-      (testDir / "isni0.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>0000 0001 2103 2683</dcx-dai:ISNI>")),
-      (testDir / "isni1.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>0000000121032268</dcx-dai:ISNI>")),
-      (testDir / "isni2.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>")),
-      (testDir / "isni3.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI: 0000 0001 2103 2268</dcx-dai:ISNI>")),
-      (testDir / "isni4.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI:0000 0001 2103 2268</dcx-dai:ISNI>")),
-      (testDir / "isni5.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI 0000 0001 2103 2268</dcx-dai:ISNI>")),
-      (testDir / "isni6.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI0000000121032268</dcx-dai:ISNI>")),
-      (testDir / "orcid1.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>https://orcid.org/0000-0002-1825-009x</dcx-dai:ORCID>")),
-      (testDir / "orcid2.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>0000-0002-1825-009X</dcx-dai:ORCID>")),
-      (testDir / "dai1.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789</dcx-dai:DAI>")),
-      (testDir / "dai2.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789x</dcx-dai:DAI>")),
-      (testDir / "dai3.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789X</dcx-dai:DAI>")),
-      (testDir / "dai4.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>info:eu-repo/dai/nl/123456789</dcx-dai:DAI>")),
+      (testDir / "isni0.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>0000 0001 2103 2683</dcx-dai:ISNI>")),
+      (testDir / "isni1.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>0000000121032268</dcx-dai:ISNI>")),
+      (testDir / "isni2.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>")),
+      (testDir / "isni3.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI: 0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni4.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI:0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni5.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI 0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni6.xml").write(modify(".*</dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI0000000121032268</dcx-dai:ISNI>")),
+      (testDir / "orcid1.xml").write(modify(".*</dcx-dai:ORCID>.*", "<dcx-dai:ORCID>https://orcid.org/0000-0002-1825-009x</dcx-dai:ORCID>")),
+      (testDir / "orcid2.xml").write(modify(".*</dcx-dai:ORCID>.*", "<dcx-dai:ORCID>0000-0002-1825-009X</dcx-dai:ORCID>")),
+      (testDir / "dai1.xml").write(modify(".*</dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789</dcx-dai:DAI>")),
+      (testDir / "dai2.xml").write(modify(".*</dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789x</dcx-dai:DAI>")),
+      (testDir / "dai3.xml").write(modify(".*</dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789X</dcx-dai:DAI>")),
+      (testDir / "uri1.xml").write(modify(".*</dct:license>.*", """<dct:license xsi:type="dct:URI">https://creativecommons.org/licenses/by-sa/4.0/</dct:license>""")),
+      (testDir / "uri2").write(modify(".*</dct:license>.*", """<dct:license xsi:type="dct:URI">https://creativecommons.org/licenses/by-sa/4.0</dct:license>""")),
+      (testDir / "uri3").write(modify(".*</dct:license>.*", """<dct:license xsi:type="dct:URI">http://creativecommons.org/licenses/by-sa/4.0</dct:license>""")),
+      (testDir / "uri4.xml").write(modify(".*</dct:license>.*",
+        """<dct:license xsi:type="dct:URI">
+          |    https://creativecommons.org/licenses/by-sa/4.0/
+          |</dct:license>""".stripMargin
+      )),
     )
   }
 
-  "ISNI validation" should "report X as 17th digit" in {
+  "ISNI pattern" should "report X as 17th digit" in {
     validate(modify(
       """.*<dcx-dai:ISNI>.*""",
       "<dcx-dai:ISNI>00000001210322683X</dcx-dai:ISNI>"
@@ -63,41 +78,46 @@ class DdmSchemaSpec extends SchemaValidationFixture {
     )) should notMatchRegexpInXsd
   }
 
-  "DAI validation" should "report missing check digit with only 8 digits" in {
+  "DAI pattern" should "report missing check digit with only 8 digits" in {
     validate(modify(
       """.*<dcx-dai:DAI>.*""",
       "<dcx-dai:DAI>12345678</dcx-dai:DAI>"
     )) should notMatchRegexpInXsd
   }
 
-  "relation validation" should "report an invalid DOI" in pendingUntilFixed {
-    validate(modify(
-      ".*</ddm:relation>.*",
-      """<ddm:relation scheme="id-type:DOI" href="https://doi.org/42">42</ddm:relation>"""
-    )) shouldBe a[Failure[_]]
-  }
-
-  it should "report an inconsistent DOI" in pendingUntilFixed {
-    validate(modify(
-      ".*</ddm:relation>.*",
-      """<ddm:relation scheme="id-type:DOI" href="https://doi.org/abc">xyz</ddm:relation>"""
-    )) shouldBe a[Failure[_]]
-  }
-
-  it should "report an XSS attack" in pendingUntilFixed {
+  "href pattern" should "report an XSS attack" in pendingUntilFixed {
     // validation actually implemented by https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/74
     // though it might be implemented with an XSD pattern
     validate(modify(
       ".*</ddm:relation>.*",
       """<ddm:relation xml:lang="nld" href="javascript:alert('XSS')">xxx</ddm:relation>"""
-    )) shouldBe a[Failure[_]]
+    )) should notMatchRegexpInXsd
   }
 
-  private def modify(lineMatches: String, replacement: String) = {
-    File("src/main/resources/examples/ddm/example1.xml")
-      .contentAsString.split("\n")
-      .map(line => if (line.matches(lineMatches)) replacement
-                   else line
-      ).mkString("\n")
+  it should "report an invalid DOI" in pendingUntilFixed {
+    // validation actually implemented by https://github.com/DANS-KNAW/easy-validate-dans-bag/blob/abae81c4b19c2c45ca686d37c3406f4b748ec7a7/src/main/scala/nl.knaw.dans.easy.validatebag/rules/metadata/package.scala#L45-L47
+    // though it might be implemented with an XSD pattern
+    validate(modify(
+      ".*</ddm:relation>.*",
+      """<ddm:relation scheme="id-type:DOI" href="https://doi.org/42">42</ddm:relation>"""
+    )) should notMatchRegexpInXsd
+  }
+
+  private def notMatchRegexpInXsd: Matcher[Any] = matchPattern {
+    case Failure(e: SAXParseException) if e.getMessage.contains("is not facet-valid with respect to pattern") =>
+  }
+
+  private def modify(lineMatches: String, replacement: String): String = {
+
+    def replace(line: String) = {
+      if (line.matches(lineMatches)) replacement
+      else line
+    }
+
+    if (!toModify.exists(_.matches(lineMatches))) {
+      // prevent false positives
+      fail(s"can't find $lineMatches")
+    }
+    toModify.map(replace).mkString("\n")
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
@@ -32,10 +32,17 @@ class DdmSchemaSpec extends SchemaValidationFixture {
     exampleDir / "abr-type/example1.xml",
   )
 
-  "DOI validation" should "fail on a relation" in pendingUntilFixed {
+  "relation validation" should "report an invalid DOI" in pendingUntilFixed {
     validateWithLocal(modify(
       ".*</ddm:relation>.*",
       """<ddm:relation scheme="id-type:DOI" href="https://doi.org/42">42</ddm:relation>"""
+    )) shouldBe a[Failure[_]]
+  }
+
+  it should "an XSS attack" in pendingUntilFixed {
+    validateWithLocal(modify(
+      ".*</ddm:relation>.*",
+      """<ddm:relation xml:lang="nld" href="javascript:alert('XSS')">xxx</ddm:relation>"""
     )) shouldBe a[Failure[_]]
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
@@ -18,6 +18,8 @@ package nl.knaw.dans.easy.schemaExamples
 import better.files.File
 import org.scalatest.prop.TableFor1
 
+import scala.util.Failure
+
 class DdmSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/md/ddm/ddm.xsd"
@@ -29,4 +31,19 @@ class DdmSchemaSpec extends SchemaValidationFixture {
     exampleDir / "ddm/example2.xml",
     exampleDir / "abr-type/example1.xml",
   )
+
+  "DOI validation" should "fail on a relation" in pendingUntilFixed {
+    validateWithLocal(modify(
+      ".*</ddm:relation>.*",
+      """<ddm:relation scheme="id-type:DOI" href="https://doi.org/42">42</ddm:relation>"""
+    )) shouldBe a[Failure[_]]
+  }
+
+  private def modify(lineMatches: String, replacement: String) = {
+    File("src/main/resources/examples/ddm/example1.xml")
+      .contentAsString.split("\n")
+      .map(line => if (line.matches(lineMatches)) replacement
+                   else line
+      ).mkString("\n")
+  }
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
@@ -39,7 +39,7 @@ class DdmSchemaSpec extends SchemaValidationFixture {
     )) shouldBe a[Failure[_]]
   }
 
-  it should "an XSS attack" in pendingUntilFixed {
+  it should "report an XSS attack" in pendingUntilFixed {
     validateWithLocal(modify(
       ".*</ddm:relation>.*",
       """<ddm:relation xml:lang="nld" href="javascript:alert('XSS')">xxx</ddm:relation>"""

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
@@ -24,23 +24,70 @@ class DdmSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/md/ddm/ddm.xsd"
   override val localSchemaFile: String = lastLocalXsd("md", "ddm.xsd")
-  override val examples: TableFor1[File] = Table("file",
-    exampleDir / "dcx-dai/example1.xml",
-    exampleDir / "dcx-gml/example1.xml",
-    exampleDir / "ddm/example1.xml",
-    exampleDir / "ddm/example2.xml",
-    exampleDir / "abr-type/example1.xml",
-  )
+  override val examples: TableFor1[File] = {
+    if (testDir.exists) testDir.delete()
+    testDir.createDirectories()
+    Table("file",
+      exampleDir / "dcx-dai/example1.xml",
+      exampleDir / "dcx-gml/example1.xml",
+      exampleDir / "ddm/example1.xml",
+      exampleDir / "ddm/example2.xml",
+      exampleDir / "abr-type/example1.xml",
+      (testDir / "isni0.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>0000 0001 2103 2683</dcx-dai:ISNI>")),
+      (testDir / "isni1.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>0000000121032268</dcx-dai:ISNI>")),
+      (testDir / "isni2.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683</dcx-dai:ISNI>")),
+      (testDir / "isni3.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI: 0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni4.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI:0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni5.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI 0000 0001 2103 2268</dcx-dai:ISNI>")),
+      (testDir / "isni6.xml").write(modify(".*<dcx-dai:ISNI>.*", "<dcx-dai:ISNI>ISNI0000000121032268</dcx-dai:ISNI>")),
+      (testDir / "orcid1.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>https://orcid.org/0000-0002-1825-009x</dcx-dai:ORCID>")),
+      (testDir / "orcid2.xml").write(modify(".*<dcx-dai:ORCID>.*", "<dcx-dai:ORCID>0000-0002-1825-009X</dcx-dai:ORCID>")),
+      (testDir / "dai1.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789</dcx-dai:DAI>")),
+      (testDir / "dai2.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789x</dcx-dai:DAI>")),
+      (testDir / "dai3.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>123456789X</dcx-dai:DAI>")),
+      (testDir / "dai4.xml").write(modify(".*<dcx-dai:DAI>.*", "<dcx-dai:DAI>info:eu-repo/dai/nl/123456789</dcx-dai:DAI>")),
+    )
+  }
+
+  "ISNI validation" should "report X as 17th digit" in {
+    validate(modify(
+      """.*<dcx-dai:ISNI>.*""",
+      "<dcx-dai:ISNI>00000001210322683X</dcx-dai:ISNI>"
+    )) should notMatchRegexpInXsd
+  }
+
+  it should "report X as 17th digit in URL" in {
+    validate(modify(
+      """.*<dcx-dai:ISNI>.*""",
+      "<dcx-dai:ISNI>http://isni.org/isni/0000000121032683X</dcx-dai:ISNI>"
+    )) should notMatchRegexpInXsd
+  }
+
+  "DAI validation" should "report missing check digit with only 8 digits" in {
+    validate(modify(
+      """.*<dcx-dai:DAI>.*""",
+      "<dcx-dai:DAI>12345678</dcx-dai:DAI>"
+    )) should notMatchRegexpInXsd
+  }
 
   "relation validation" should "report an invalid DOI" in pendingUntilFixed {
-    validateWithLocal(modify(
+    validate(modify(
       ".*</ddm:relation>.*",
       """<ddm:relation scheme="id-type:DOI" href="https://doi.org/42">42</ddm:relation>"""
     )) shouldBe a[Failure[_]]
   }
 
+  it should "report an inconsistent DOI" in pendingUntilFixed {
+    validate(modify(
+      ".*</ddm:relation>.*",
+      """<ddm:relation scheme="id-type:DOI" href="https://doi.org/abc">xyz</ddm:relation>"""
+    )) shouldBe a[Failure[_]]
+  }
+
   it should "report an XSS attack" in pendingUntilFixed {
-    validateWithLocal(modify(
+    // validation actually implemented by https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/74
+    // though it might be implemented with an XSD pattern
+    validate(modify(
       ".*</ddm:relation>.*",
       """<ddm:relation xml:lang="nld" href="javascript:alert('XSS')">xxx</ddm:relation>"""
     )) shouldBe a[Failure[_]]

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DdmSchemaSpec.scala
@@ -15,18 +15,18 @@
  */
 package nl.knaw.dans.easy.schemaExamples
 
+import better.files.File
 import org.scalatest.prop.TableFor1
 
 class DdmSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/md/ddm/ddm.xsd"
   override val localSchemaFile: String = lastLocalXsd("md", "ddm.xsd")
-  override val examples: TableFor1[String] = Table(
-    "example",
-    "dcx-dai/example1.xml",
-    "dcx-gml/example1.xml",
-    "ddm/example1.xml",
-    "ddm/example2.xml",
-    "abr-type/example1.xml",
+  override val examples: TableFor1[File] = Table("file",
+    exampleDir / "dcx-dai/example1.xml",
+    exampleDir / "dcx-gml/example1.xml",
+    exampleDir / "ddm/example1.xml",
+    exampleDir / "ddm/example2.xml",
+    exampleDir / "abr-type/example1.xml",
   )
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
@@ -29,6 +29,7 @@ class DefaultsSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks
       ("md/emd", "sdc.xsd"),
       ("md/emd", "xml.xsd"),
       ("bag/metadata/files", "files.xsd"),
+      ("bag/metadata/agreements", "agreements.xsd"),
     )
     forEvery(xsds) { (path, file) =>
       File(lastLocalXsd(path, file))
@@ -41,11 +42,6 @@ class DefaultsSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks
     // different path for version and version-less
     File(lastLocalXsd("md", "ddm.xsd"))
       .contentAsString shouldBe (schemaDir / "md/ddm/ddm.xsd").contentAsString
-  }
-
-  it should "equal not qualified agreements.xsd" in {
-    File(lastLocalXsd("bag/metadata/agreements", "agreements.xsd"))
-      .contentAsString shouldBe (schemaDir / "bag/metadata/agreements/agreements.xsd").contentAsString
   }
 
   "SchemaSpec classes" should "test all examples" in {

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
@@ -37,7 +37,7 @@ class DefaultsSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks
     }
   }
 
-  it should "equal not qualified ddm.xsd" in {
+  "last local ddm.XSD" should "equal not qualified ddm.xsd" in {
     // an exception to the table driven tests:
     // different path for version and version-less
     File(lastLocalXsd("md", "ddm.xsd"))

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
@@ -50,9 +50,9 @@ class DefaultsSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks
 
   "SchemaSpec classes" should "test all examples" in {
     exampleDir
-      .walk()
+      .listRecursively()
       .count(!_.isDirectory) shouldBe
-      File("src/test/scala/nl/knaw/dans/easy/schemaExamples").walk().collect {
+      File("src/test/scala/nl/knaw/dans/easy/schemaExamples").listRecursively().collect {
         case f: File if f.name.endsWith("SchemaSpec.scala") => countTestedFiles(f)
       }.sum
   }
@@ -60,6 +60,6 @@ class DefaultsSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks
   private def countTestedFiles(file: File) = {
     file.contentAsString
       .split("\n")
-      .count(_.contains(""".xml","""))
+      .count(_.endsWith(""".xml","""))
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/FilesSchemaSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/FilesSchemaSpec.scala
@@ -15,14 +15,14 @@
  */
 package nl.knaw.dans.easy.schemaExamples
 
+import better.files.File
 import org.scalatest.prop.TableFor1
 
 class FilesSchemaSpec extends SchemaValidationFixture {
 
   override val publicSchema: String = s"$httpsEasySchemaBase/bag/metadata/files/files.xsd"
   override val localSchemaFile: String = lastLocalXsd("bag/metadata/files", "files.xsd")
-  override val examples: TableFor1[String] = Table(
-    "example",
-    "bag/files/example1.xml",
+  override val examples: TableFor1[File] = Table("file",
+    exampleDir / "bag/files/example1.xml",
   )
 }

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala
@@ -24,6 +24,7 @@ import javax.xml.transform.Source
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.{ Schema, SchemaFactory }
 import nl.knaw.dans.lib.error._
+import org.scalatest.matchers.Matcher
 import org.scalatest.prop.{ TableDrivenPropertyChecks, TableFor1 }
 import org.scalatest.{ FlatSpec, Matchers }
 
@@ -90,6 +91,15 @@ trait SchemaValidationFixture extends FlatSpec with Matchers with TableDrivenPro
     // reported with: ...lastLocalIsPublic was false
     val newPublicSchema = localSchemaFile.replace(schemaDir.toString(), httpsEasySchemaBase)
     Try(new URL(newPublicSchema).openStream()).fold(_ => false, _ => true)
+  }
+
+  def notMatchRegexpInXsd: Matcher[Any] = matchPattern {
+    case Failure(e: SAXParseException) if e.getMessage.contains("is not facet-valid with respect to pattern") =>
+  }
+
+  def validateWithLocal(xml: String): Try[Unit] = {
+    assume(schemaIsOnline(triedLocalSchema))
+    validate(triedLocalSchema, xml)
   }
 
   def validate(schema: Try[Schema], xmlString: String): Try[Unit] = {

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala
@@ -74,7 +74,7 @@ trait SchemaValidationFixture extends FlatSpec with Matchers with TableDrivenPro
     case Failure(e: SAXParseException) if e.getMessage.contains("is not facet-valid with respect to pattern") =>
   }
 
-  def validateWithLocal(xml: String): Try[Unit] = {
+  def validate(xml: String): Try[Unit] = {
     assume(schemaIsOnline(triedLocalSchema))
     validate(triedLocalSchema, xml)
   }


### PR DESCRIPTION
Fixes EASY-2614: ISNI regexp allowed 17 digits if the last is an X 

#### When applied it will
* test for ISNI edge cases
* some other tests from `easy-validate-dans-bag`
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
* [x] depends on https://github.com/DANS-KNAW/easy-schema/pull/80