### PR TITLE
EASY-2771: custom User-Agent headers for http-request of DC schemas

### DIFF
--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala
@@ -31,6 +31,10 @@ import scala.util.{ Failure, Success, Try }
 import scala.xml._
 
 trait SchemaValidationFixture extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks {
+
+  // Some (XSD) servers will deny requests if the User-Agent is set to the default value for Java
+  //System.setProperty("http.agent", "Test")
+
   lazy val testDir: File = currentWorkingDirectory / "target" / "test" / getClass.getSimpleName
 
   val publicSchema: String


### PR DESCRIPTION
Fixes EASY-

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
