### PR TITLE
DD-268: Add examples of reportNumber

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <easy.schema.version>3.4.1</easy.schema.version>
+        <easy.schema.version>3.4.9</easy.schema.version>
     </properties>
 
     <scm>

--- a/src/main/resources/examples/ddm/example1.xml
+++ b/src/main/resources/examples/ddm/example1.xml
@@ -22,7 +22,7 @@
     xmlns:dct="http://purl.org/dc/terms/"
     xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
     xsi:schemaLocation="
-        http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
+    http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
         http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd
     ">
     
@@ -41,9 +41,8 @@
         The use of xml:lang and xsi:type attributes, where applicable, is recommended.
         -->
         
-        <!-- One or more dc:title, dct:title, dct:alternative -->
+        <!-- Exactly one dc:title -->
         <dc:title xml:lang="en">Title of the dataset</dc:title>
-        <dc:title xml:lang="nl">Titel van de dataset</dc:title>
         
         <!-- One or more dc:description, dct:description, dct:abstract, dct:tableOfContents -->
         <dc:description xml:lang="la">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dc:description>
@@ -128,6 +127,19 @@
             <ddm:fundingProgramme>Gravitation</ddm:fundingProgramme>
             <ddm:awardNumber awardURI="info:eu-repo/grantAgreement/NWO/Gravitation/024.001.006">024.001.006</ddm:awardNumber>
         </ddm:funding>
+        
+        <!-- In case of a dutch archaeological dataset, use reportNumber to record the specific report this dataset is about -->
+        <ddm:reportNumber 
+            valueURI="https://data.cultureelerfgoed.nl/term/id/abr/relevant-value-URI" 
+            schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/7a99aaba-c1e7-49a4-9dd8-d295dbcc870e" 
+            subjectScheme="ABR Rapporten"
+            reportNo="123">Report Series 123</ddm:reportNumber>
+        
+        
+        <ddm:acquisitionMethod 
+            subjectScheme="ABR verwervingswijzen" 
+            schemeURI="https://data.cultureelerfgoed.nl/term/id/abr/554ca1ec-3ed8-42d3-ae4b-47bcb848b238" 
+            valueURI="https://data.cultureelerfgoed.nl/term/id/abr/relevant-value-URI">Booronderzoek</ddm:acquisitionMethod>
         
         <!-- Use explicitely typed values, when possible -->
         <dct:issued xsi:type="dct:W3CDTF">2012-10-09</dct:issued>

--- a/src/main/resources/examples/ddm/example2.xml
+++ b/src/main/resources/examples/ddm/example2.xml
@@ -28,7 +28,7 @@
         xmlns:dcterms="http://purl.org/dc/terms/"
 
         xsi:schemaLocation="
-            http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
+        http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd
             http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd
         ">
 
@@ -51,9 +51,8 @@
         The use of xml:lang and xsi:type attributes, where applicable, is recommended.
         -->
 
-        <!-- One or more dc:title, dct:title, dct:alternative -->
-        <dc:title xml:lang="en">Title of the dataset 6</dc:title>
-        <dc:title xml:lang="nl">Titel van de dataset</dc:title>
+        <!-- One dc:title / dct:title -->
+        <dct:title xml:lang="en">Title of the dataset 6</dct:title>
 
         <!-- One or more dc:description, dct:description, dct:abstract, dct:tableOfContents -->
         <dc:description xml:lang="la">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dc:description>
@@ -94,6 +93,7 @@
 
     <!-- DDM instances MAY have one ddm:dcmiMetadata element -->
     <ddm:dcmiMetadata>
+        <dc:title>optionally another title</dc:title>
         <dcterms:audience xsi:type='narcis:DisciplineType'>D24000</dcterms:audience>
 
         <!-- Sword-V1 returns HTTP/1.1 500 Internal Server Error with the following fields -->

--- a/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schemaExamples/DefaultsSpec.scala
@@ -29,6 +29,8 @@ class DefaultsSpec extends AnyFlatSpec with Matchers with TableDrivenPropertyChe
       ("md/emd", "qdc.xsd"),
       ("md/emd", "sdc.xsd"),
       ("md/emd", "xml.xsd"),
+      ("bag/metadata/afm", "afm.xsd"),
+      ("bag/metadata/amd", "amd.xsd"),
       ("bag/metadata/files", "files.xsd"),
       ("bag/metadata/agreements", "agreements.xsd"),
     )


### PR DESCRIPTION
Fixes DD-268

#### When applied it will
* Add examples of reportNumber
* Add examples of  acquisitionMethod
* Allow only 1 profile title

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-schema                      | [PR#90](https://github.com/DANS-KNAW/easy-schema/pull/90)     | ..
