### PR TITLE
DD-832: all schemas local

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Development cycle
 * Run `mvn clean install` in `easy-schema`.
 * Update `<easy.schema.version>` to the SNAPSHOT version of `easy-schema` in `easy-schema-examples.pom`.
 * Run `mvn clean generate-test-resources` in this project. 
-* The fixture replaces the references to dans.knaw to local files, but not recursively.
-  When changes are made to the files under `easy-schema/src/main/resources/extern`
-  apply the following replacements to the files under `easy/easy-schema-examples/target/easy-schema`
+* The fixture replaces the references to dans.knaw when reading the examples, the XSDs are not affected.
+  Apply the following replacements to the files under `easy/easy-schema-examples/target/easy-schema`
 
       schemaLocation="https://easy.dans.knaw.nl/schemas
       schemaLocation="file:///<ABSOLUTE-PATH-TO>/easy-schema-examples/target/easy-schema
 
-* Update the examples with an explicit schema version and fix failing tests.
+* Run `mvn clean install` in this project.
+* Fix failing tests, e.g. `"primary examples" should "reference the last schema version"`
+  means: update the version number in `xsi:schemaLocation` of the failing example.
 * Merge both projects, publish schema's.
 * The test ignored above should now succeed.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Development cycle
 * Run `mvn clean install` in `easy-schema`.
 * Update `<easy.schema.version>` to the SNAPSHOT version of `easy-schema` in `easy-schema-examples.pom`.
 * Run `mvn clean generate-test-resources` in this project. 
-* The fixture replaces the references to dans.knaw to local file, but not recursively.
+* The fixture replaces the references to dans.knaw to local files, but not recursively.
   When changes are made to the files under `easy-schema/src/main/resources/extern`
   apply the following replacements to the files under `easy/easy-schema-examples/target/easy-schema`
 
-      schemaLocation="https://easy.dans.knaw.nl/schemas
-      schemaLocation="file:///<HOME>/git/service/easy/easy-schema-examples/target/easy-schema
+      schemaLocation="file:///Users/jokep/git/service/easy/easy-schema-examples/target/easy-schema
+      schemaLocation="file:///<ABSOLUTE-PATH-TO>/easy-schema-examples/target/easy-schema
 
 * Update the examples and fix failing tests.
 * ~~Some tests will be ignored because of `assume(lastLocalIsPublic)`, reported with `...lastLocalIsPublic was false` messages.~~

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Development cycle
       schemaLocation="file:///Users/jokep/git/service/easy/easy-schema-examples/target/easy-schema
       schemaLocation="file:///<ABSOLUTE-PATH-TO>/easy-schema-examples/target/easy-schema
 
-* Update the examples and fix failing tests.
-* ~~Some tests will be ignored because of `assume(lastLocalIsPublic)`, reported with `...lastLocalIsPublic was false` messages.~~
-  Seems explicitly [requested](https://github.com/DANS-KNAW/easy-schema-examples/pull/1/files#r265880649) but is dropped in the next PR
+* Update the examples with an explicit schema version and fix failing tests.
 * Merge both projects, publish schema's.
 * The test ignored above should now succeed.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@ A collection of examples of the XML schema's used by EASY. These schema's are pu
 Development cycle
 -----------------
 
-* Add new version of XSD to https://github.com/DANS-KNAW/easy-schema.
+* Make changes to your local [easy-schema](https://github.com/DANS-KNAW/easy-schema).
 * Run `mvn clean install` in `easy-schema`.
-* Run `mvn clean generate-test-resources` in this project.
+* Update `<easy.schema.version>` to the SNAPSHOT version of `easy-schema` in `easy-schema-examples.pom`.
+* Run `mvn clean generate-test-resources` in this project. 
+* The fixture replaces the references to dans.knaw to local file, but not recursively.
+  When changes are made to the files under `easy-schema/src/main/resources/extern`
+  apply the following replacements to the files under `easy/easy-schema-examples/target/easy-schema`
+
+      schemaLocation="https://easy.dans.knaw.nl/schemas
+      schemaLocation="file:///<HOME>/git/service/easy/easy-schema-examples/target/easy-schema
+
 * Update the examples and fix failing tests.
-* Some tests will be ignored because of `assume(lastLocalIsPublic)`, reported with `...lastLocalIsPublic was false` messages.
+* ~~Some tests will be ignored because of `assume(lastLocalIsPublic)`, reported with `...lastLocalIsPublic was false` messages.~~
+  Seems explicitly [requested](https://github.com/DANS-KNAW/easy-schema-examples/pull/1/files#r265880649) but is dropped in the next PR
 * Merge both projects, publish schema's.
 * The test ignored above should now succeed.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Development cycle
   When changes are made to the files under `easy-schema/src/main/resources/extern`
   apply the following replacements to the files under `easy/easy-schema-examples/target/easy-schema`
 
-      schemaLocation="file:///Users/jokep/git/service/easy/easy-schema-examples/target/easy-schema
+      schemaLocation="https://easy.dans.knaw.nl/schemas
       schemaLocation="file:///<ABSOLUTE-PATH-TO>/easy-schema-examples/target/easy-schema
 
 * Update the examples with an explicit schema version and fix failing tests.

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <easy.schema.version>3.4.10</easy.schema.version>
+        <easy.schema.version>3.5.9-SNAPSHOT</easy.schema.version>
     </properties>
 
     <scm>

--- a/src/main/resources/examples/dcx-dai/example2.xml
+++ b/src/main/resources/examples/dcx-dai/example2.xml
@@ -17,7 +17,7 @@
 
 -->
 <dcx-dai:creatorDetails xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-                        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/dai/ https://easy.dans.knaw.nl/schemas/dcx/2020/03/dcx-dai.xsd">
+                        xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/dai/ https://easy.dans.knaw.nl/schemas/dcx/2022/06/dcx-dai.xsd">
     <dcx-dai:author>
         <dcx-dai:titles xml:lang="en">B.L.I.S.</dcx-dai:titles>
         <dcx-dai:initials>J.P.H.</dcx-dai:initials>


### PR DESCRIPTION
Fixes DD-832: all schemas local

#### When applied it will
* updated README to prevent misinterpretation, and added a step
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] possibly the breaking test that should be fixed after publishing (fixed with related pull request) https://github.com/DANS-KNAW/easy-schema-examples/blob/914f99e138c1ce19fdbc613eedbbbe053bc26ac6/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala#L68
* [ ] I don't trust the reason why `CollectionsDmoSchemaSpec` is ignored dynamically. It says: Cannot resolve the name 'dc:dc'; on an earlier day (possibly another test class): Cannot resolve the name 'xml:lang' https://github.com/DANS-KNAW/easy-schema-examples/blob/914f99e138c1ce19fdbc613eedbbbe053bc26ac6/src/test/scala/nl/knaw/dans/easy/schemaExamples/SchemaValidationFixture.scala#L61


#### Related pull requests on github
https://github.com/DANS-KNAW/easy-schema/pull/106
